### PR TITLE
Use 'eventuals::Pipe' in 'Endpoint'

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "submodules/eventuals"]
+	path = submodules/eventuals
+	url = https://github.com/3rdparty/eventuals.git

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -1,5 +1,21 @@
 workspace(name = "com_github_3rdparty_eventuals_grpc")
 
+########################################################################
+
+# NOTE: we pull in 'eventuals' as a local repository pointing to the git
+# submodule that we have so that we can do do more efficient
+# development between the two repositories. We'll remove this for
+# releases!
+local_repository(
+    name = "com_github_3rdparty_eventuals",
+    path = "submodules/eventuals"
+)
+
+load("@com_github_3rdparty_eventuals//bazel:repos.bzl", eventuals_repos = "repos")
+eventuals_repos(external = False)
+
+########################################################################
+
 load("//bazel:repos.bzl", "repos")
 repos(external = False)
 

--- a/eventuals/grpc/server.cc
+++ b/eventuals/grpc/server.cc
@@ -114,7 +114,7 @@ Server::Server(
     serve->service->Register(this);
 
     serve->task.emplace(
-        Task<void>([service]() {
+        Task::Of<void>([service]() {
           // Use a separate preemptible scheduler context to serve
           // each service so that we correctly handle any waiting
           // (e.g., on 'Lock' or 'Wait').

--- a/eventuals/grpc/server.h
+++ b/eventuals/grpc/server.h
@@ -701,7 +701,6 @@ auto UnaryEpilogue(ServerCall<Request, Response>& call) {
          })
       | Just(::grpc::Status::OK)
       | Catch([&](auto&&...) {
-           call.context()->TryCancel();
            return Just(
                ::grpc::Status(::grpc::UNKNOWN, "error"));
          })
@@ -723,7 +722,6 @@ auto StreamingEpilogue(ServerCall<Request, Response>& call) {
       | Loop()
       | Just(::grpc::Status::OK)
       | Catch([&](auto&&...) {
-           call.context()->TryCancel();
            return Just(
                ::grpc::Status(::grpc::UNKNOWN, "error"));
          })

--- a/eventuals/grpc/server.h
+++ b/eventuals/grpc/server.h
@@ -37,7 +37,7 @@ namespace grpc {
 
 ////////////////////////////////////////////////////////////////////////
 
-using eventuals::detail::operator|;
+using eventuals::operator|;
 
 ////////////////////////////////////////////////////////////////////////
 
@@ -50,7 +50,7 @@ class Service {
  public:
   virtual ~Service() = default;
 
-  virtual Task<void> Serve() = 0;
+  virtual Task::Of<void> Serve() = 0;
 
   virtual char const* name() = 0;
 
@@ -521,7 +521,7 @@ class Server : public Synchronizable {
   struct Serve {
     Service* service;
     Interrupt interrupt;
-    std::optional<Task<void>> task;
+    std::optional<Task::Of<void>> task;
     std::atomic<bool> done = false;
   };
 
@@ -529,7 +529,7 @@ class Server : public Synchronizable {
 
   struct Worker {
     Interrupt interrupt;
-    std::optional<Task<void>::With<::grpc::ServerCompletionQueue*>> task;
+    std::optional<Task::Of<void>::With<::grpc::ServerCompletionQueue*>> task;
     std::atomic<bool> done = false;
   };
 

--- a/protoc-gen-eventuals/templates/eventuals.cc.j2
+++ b/protoc-gen-eventuals/templates/eventuals.cc.j2
@@ -27,7 +27,7 @@ using eventuals::grpc::Stream;
 using namespace {{ namespaces | join('::') }}::eventuals;
 
 {% for service in services -%}
-Task<void> {{ service.name }}::TypeErasedService::Serve() {
+Task::Of<void> {{ service.name }}::TypeErasedService::Serve() {
   return [this]() {
     return DoAll(
 {%- for method in service.methods %}

--- a/protoc-gen-eventuals/templates/eventuals.h.j2
+++ b/protoc-gen-eventuals/templates/eventuals.h.j2
@@ -20,7 +20,7 @@ struct {{ service.name }} {
 
   class TypeErasedService : public ::eventuals::grpc::Service {
    public:
-    ::eventuals::Task<void> Serve() override;
+    ::eventuals::Task::Of<void> Serve() override;
 
     char const* name() override {
       return {{ service.name }}::service_full_name();
@@ -34,7 +34,7 @@ struct {{ service.name }} {
     {%- if method.server_streaming -%}
         Generator
     {%- else -%}
-        Task
+        Task::Of
     {%- endif -%}
     {#...#}<const {{ method.output_type.split('.') | join('::') }}&>
 {%- endset %}
@@ -63,7 +63,7 @@ struct {{ service.name }} {
     {%- if method.server_streaming -%}
         Generator
     {%- else -%}
-        Task
+        Task::Of
     {%- endif -%}
     {#...#}<const {{ method.output_type.split('.') | join('::') }}&>
 {%- endset %}

--- a/test/helloworld.eventuals.cc
+++ b/test/helloworld.eventuals.cc
@@ -26,7 +26,7 @@ namespace eventuals {
 
 ////////////////////////////////////////////////////////////////////////
 
-Task<void> Greeter::TypeErasedService::Serve() {
+Task::Of<void> Greeter::TypeErasedService::Serve() {
   return [this]() {
     return DoAll(
                // SayHello

--- a/test/helloworld.eventuals.h
+++ b/test/helloworld.eventuals.h
@@ -18,7 +18,7 @@ class Greeter {
 
   class TypeErasedService : public ::eventuals::grpc::Service {
    public:
-    ::eventuals::Task<void> Serve() override;
+    ::eventuals::Task::Of<void> Serve() override;
 
     char const* name() override {
       return Greeter::service_full_name();
@@ -27,7 +27,7 @@ class Greeter {
    protected:
     virtual ~TypeErasedService() = default;
 
-    virtual ::eventuals::Task<HelloReply> TypeErasedSayHello(
+    virtual ::eventuals::Task::Of<HelloReply> TypeErasedSayHello(
         std::tuple<
             TypeErasedService*, // this
             ::grpc::GenericServerContext*,
@@ -36,7 +36,7 @@ class Greeter {
 
   template <typename Implementation>
   class Service : public TypeErasedService {
-    ::eventuals::Task<HelloReply> TypeErasedSayHello(
+    ::eventuals::Task::Of<HelloReply> TypeErasedSayHello(
         std::tuple<
             TypeErasedService*,
             ::grpc::GenericServerContext*,


### PR DESCRIPTION
Replaces the functionality in 'Endpoint' with the generic 'eventuals::Pipe' that was specifically inspired by this code.