### PR TITLE
Remove redundant GitHub action's step

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -24,11 +24,6 @@ jobs:
       - name: Check for bazel
         run: bazel --version
 
-      - name: Install LLVM and Clang
-        uses: KyleMayes/install-llvm-action@v1
-        with:
-          version: "12.0"  
-
       - name: Build
         run: bazel build --spawn_strategy=local --copt="-g" --strip="never" :grpc
 


### PR DESCRIPTION
This PR removes redundant step in the `ubuntu.yml`.
Why? The answer is the following: check [this](https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-README.md).
As you can see from the link above we already have preinstalled Clang on Ubuntu 20.04, that's why `KyleMayes/install-llvm-action` is not relevant for us.