### PR TITLE
Cleanup: prefer CHECK_EQ(a, b) to CHECK(a == b)

### DIFF
--- a/test/client-death-test.cc
+++ b/test/client-death-test.cc
@@ -44,22 +44,22 @@ TEST_F(EventualsGrpcTest, ClientDeathTest) {
 
   auto wait_for_fork = [&]() {
     int _;
-    CHECK(read(pipes.fork[0], &_, sizeof(int)) > 0);
+    CHECK_GT(read(pipes.fork[0], &_, sizeof(int)), 0);
   };
 
   auto notify_forked = [&]() {
     int _ = 1;
-    CHECK(write(pipes.fork[1], &_, sizeof(int)) > 0);
+    CHECK_GT(write(pipes.fork[1], &_, sizeof(int)), 0);
   };
 
   auto wait_for_port = [&]() {
     int port;
-    CHECK(read(pipes.port[0], &port, sizeof(int)) > 0);
+    CHECK_GT(read(pipes.port[0], &port, sizeof(int)), 0);
     return port;
   };
 
   auto send_port = [&](int port) {
-    CHECK(write(pipes.port[1], &port, sizeof(port)) > 0);
+    CHECK_GT(write(pipes.port[1], &port, sizeof(port)), 0);
   };
 
   auto client = [&]() {

--- a/test/server-death-test.cc
+++ b/test/server-death-test.cc
@@ -33,12 +33,12 @@ TEST_F(EventualsGrpcTest, ServerDeathTest) {
 
   auto wait_for_port = [&]() {
     int port;
-    CHECK(read(pipefds[0], &port, sizeof(int)) > 0);
+    CHECK_GT(read(pipefds[0], &port, sizeof(int)), 0);
     return port;
   };
 
   auto send_port = [&](int port) {
-    CHECK(write(pipefds[1], &port, sizeof(port)) > 0);
+    CHECK_GT(write(pipefds[1], &port, sizeof(port)), 0);
   };
 
   auto server = [&]() {


### PR DESCRIPTION
The former prints more useful error messages containing both values. See
https://github.com/google/glog#check-macros.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/3rdparty/eventuals-grpc/61)
<!-- Reviewable:end -->
