### PR TITLE
Ensure we don't call 'Wait()' on a 'grpc::Server' more than once

### DIFF
--- a/test/unary.cc
+++ b/test/unary.cc
@@ -93,4 +93,10 @@ TEST_F(EventualsGrpcTest, Unary) {
   EXPECT_TRUE(status.ok());
 
   EXPECT_FALSE(cancelled.get());
+
+  // NOTE: explicitly calling 'Shutdown()' and 'Wait()' to test that
+  // they can be called safely since the destructor for a server
+  // _also_ trys to call them .
+  server->Shutdown();
+  server->Wait();
 }


### PR DESCRIPTION
Doing so will cause the program to abort. This currently can be
manifested by explicitly because the destructor for an
'eventuals::grpc::Server' might call 'Wait()' after it was already
called explicitly.