### PR TITLE
Ignore all bazel output directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,4 @@
 .vs
 .vscode
-bazel-bin
-bazel-out
-bazel-stout-grpc
-bazel-testlogs
+bazel-*
 *~


### PR DESCRIPTION
This adds bazel-eventuals-grpc to the ignore list, as well as any other
similar auto-generated directories that get added later.
