### PR TITLE
Fix ClientContext use-after-free

### DIFF
--- a/test/cancelled-by-client.cc
+++ b/test/cancelled-by-client.cc
@@ -4,6 +4,7 @@
 #include "eventuals/let.h"
 #include "eventuals/then.h"
 #include "examples/protos/helloworld.grpc.pb.h"
+#include "grpcpp/client_context.h"
 #include "gtest/gtest.h"
 #include "test/test.h"
 
@@ -60,8 +61,10 @@ TEST_F(EventualsGrpcTest, CancelledByClient) {
       grpc::InsecureChannelCredentials(),
       pool.Borrow());
 
+  ::grpc::ClientContext context;
+
   auto call = [&]() {
-    return client.Call<Greeter, HelloRequest, HelloReply>("SayHello")
+    return client.Call<Greeter, HelloRequest, HelloReply>("SayHello", &context)
         | Then(Let([&](auto& call) {
              call.context()->TryCancel();
              return call.Finish();

--- a/test/cancelled-by-server.cc
+++ b/test/cancelled-by-server.cc
@@ -4,6 +4,7 @@
 #include "eventuals/let.h"
 #include "eventuals/then.h"
 #include "examples/protos/helloworld.grpc.pb.h"
+#include "grpcpp/client_context.h"
 #include "gtest/gtest.h"
 #include "test/test.h"
 

--- a/test/client-death-test.cc
+++ b/test/client-death-test.cc
@@ -74,8 +74,10 @@ TEST_F(EventualsGrpcTest, ClientDeathTest) {
         grpc::InsecureChannelCredentials(),
         pool.Borrow());
 
+    ::grpc::ClientContext context;
+
     auto call = [&]() {
-      return client.Call<Greeter, HelloRequest, HelloReply>("SayHello")
+      return client.Call<Greeter, HelloRequest, HelloReply>("SayHello", &context)
           | Then([](auto&& call) {
                exit(1);
              });

--- a/test/greeter-server.cc
+++ b/test/greeter-server.cc
@@ -4,6 +4,7 @@
 #include "eventuals/loop.h"
 #include "eventuals/map.h"
 #include "eventuals/then.h"
+#include "grpcpp/client_context.h"
 #include "gtest/gtest.h"
 #include "test/helloworld.eventuals.h"
 #include "test/test.h"
@@ -64,8 +65,10 @@ TEST_F(EventualsGrpcTest, Greeter) {
       grpc::InsecureChannelCredentials(),
       pool.Borrow());
 
+  ::grpc::ClientContext context;
+
   auto call = [&]() {
-    return client.Call<Greeter, HelloRequest, HelloReply>("SayHello")
+    return client.Call<Greeter, HelloRequest, HelloReply>("SayHello", &context)
         | Then(Let([](auto& call) {
              HelloRequest request;
              request.set_name("emily");

--- a/test/server-death-test.cc
+++ b/test/server-death-test.cc
@@ -5,6 +5,7 @@
 #include "eventuals/terminal.h"
 #include "eventuals/then.h"
 #include "examples/protos/helloworld.grpc.pb.h"
+#include "grpcpp/client_context.h"
 #include "gtest/gtest.h"
 #include "test/test.h"
 
@@ -98,8 +99,10 @@ TEST_F(EventualsGrpcTest, ServerDeathTest) {
       grpc::InsecureChannelCredentials(),
       pool.Borrow());
 
+  ::grpc::ClientContext context;
+
   auto call = [&]() {
-    return client.Call<Greeter, HelloRequest, HelloReply>("SayHello")
+    return client.Call<Greeter, HelloRequest, HelloReply>("SayHello", &context)
         | Then(Let([](auto& call) {
              HelloRequest request;
              request.set_name("emily");

--- a/test/server-unavailable.cc
+++ b/test/server-unavailable.cc
@@ -2,6 +2,7 @@
 #include "eventuals/let.h"
 #include "eventuals/terminal.h"
 #include "examples/protos/helloworld.grpc.pb.h"
+#include "grpcpp/client_context.h"
 #include "gtest/gtest.h"
 #include "test/test.h"
 
@@ -27,8 +28,10 @@ TEST_F(EventualsGrpcTest, ServerUnavailable) {
       grpc::InsecureChannelCredentials(),
       pool.Borrow());
 
+  ::grpc::ClientContext context;
+
   auto call = [&]() {
-    return client.Call<Greeter, HelloRequest, HelloReply>("SayHello")
+    return client.Call<Greeter, HelloRequest, HelloReply>("SayHello", &context)
         | Then(Let([](auto& call) {
              return call.Finish();
            }));

--- a/test/streaming.cc
+++ b/test/streaming.cc
@@ -8,6 +8,7 @@
 #include "eventuals/map.h"
 #include "eventuals/then.h"
 #include "examples/protos/keyvaluestore.grpc.pb.h"
+#include "grpcpp/client_context.h"
 #include "gtest/gtest.h"
 #include "test/test.h"
 
@@ -105,11 +106,13 @@ void test_client_behavior(Handler handler) {
       grpc::InsecureChannelCredentials(),
       pool.Borrow());
 
+  ::grpc::ClientContext context;
+
   auto call = [&]() {
     return client.Call<
                Stream<keyvaluestore::Request>,
                Stream<keyvaluestore::Response>>(
-               "keyvaluestore.KeyValueStore.GetValues")
+               "keyvaluestore.KeyValueStore.GetValues", &context)
         | std::move(handler);
   };
 

--- a/test/unary.cc
+++ b/test/unary.cc
@@ -6,6 +6,7 @@
 #include "eventuals/map.h"
 #include "eventuals/then.h"
 #include "examples/protos/helloworld.grpc.pb.h"
+#include "grpcpp/client_context.h"
 #include "gtest/gtest.h"
 #include "test/test.h"
 
@@ -73,8 +74,10 @@ TEST_F(EventualsGrpcTest, Unary) {
       grpc::InsecureChannelCredentials(),
       pool.Borrow());
 
+  ::grpc::ClientContext context;
+
   auto call = [&]() {
-    return client.Call<Greeter, HelloRequest, HelloReply>("SayHello")
+    return client.Call<Greeter, HelloRequest, HelloReply>("SayHello", &context)
         | Then(Let([](auto& call) {
              HelloRequest request;
              request.set_name("emily");

--- a/test/unimplemented.cc
+++ b/test/unimplemented.cc
@@ -2,6 +2,7 @@
 #include "eventuals/grpc/server.h"
 #include "eventuals/let.h"
 #include "examples/protos/helloworld.grpc.pb.h"
+#include "grpcpp/client_context.h"
 #include "gtest/gtest.h"
 #include "test/test.h"
 
@@ -42,8 +43,10 @@ TEST_F(EventualsGrpcTest, Unimplemented) {
       grpc::InsecureChannelCredentials(),
       pool.Borrow());
 
+  ::grpc::ClientContext context;
+
   auto call = [&]() {
-    return client.Call<Greeter, HelloRequest, HelloReply>("SayHello")
+    return client.Call<Greeter, HelloRequest, HelloReply>("SayHello", &context)
         | Then(Let([](auto& call) {
              return call.Finish();
            }));


### PR DESCRIPTION
Per https://github.com/grpc/grpc/issues/16877 a ::grpc::ClientContext
must persist for the lifetime of a gRPC call, which includes persisting
past any calls to ~ClientAsyncReaderWriter().

Rather than creating temporary hidden ClientContext objects, switch to a
more familiar gRPC API style of having users declare a ClientContext
object for each call which they pass to calls. The client is responsible
for ensuring that ClientContext objects persiste beyond the lifetime of
gRPC calls (or eventuals-grpc call objects).

Fixes https://github.com/3rdparty/eventuals-grpc/issues/71.
