### PR TITLE
Pin submodules to branch main

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,8 @@
 [submodule "submodules/eventuals"]
 	path = submodules/eventuals
 	url = https://github.com/3rdparty/eventuals.git
+	branch = main
 [submodule "submodules/dev-tools"]
 	path = submodules/dev-tools
 	url = https://github.com/3rdparty/dev-tools.git
+	branch = main


### PR DESCRIPTION
To make it easier to pick up changes in submodules I suggest to pin each at main by default.