### PR TITLE
Add remote cache support

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -37,11 +37,21 @@ jobs:
       run:
         shell: bash
 
+    env:
+      GOOGLE_APPLICATION_CREDENTIALS: service_account_credentials.json
+      GOOGLE_REMOTE_CACHE: https://storage.googleapis.com/reboot-dev-eventuals-remote-cache
+
     steps:
       # Checkout the repository under $GITHUB_WORKSPACE.
       - uses: actions/checkout@v2
         with:
           submodules: "recursive"
+
+      - name: Set up remote cache credentials
+        uses: jsdaniell/create-json@1.1.2
+        with:
+          name: ${{ env.GOOGLE_APPLICATION_CREDENTIALS }}
+          json: ${{ secrets.GCP_GITHUB_INFRA_REMOTE_CACHE_CREDENTIALS }}
 
       # Install Dazel, so that we use the same build tooling in our Actions as
       # we do on our workstations.
@@ -55,6 +65,8 @@ jobs:
             --spawn_strategy=local \
             -c dbg \
             --strip="never" \
+            --remote_cache=$GOOGLE_REMOTE_CACHE \
+            --google_credentials=$GOOGLE_APPLICATION_CREDENTIALS \
             :grpc
 
       - name: Test

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -67,6 +67,7 @@ jobs:
             --strip="never" \
             --remote_cache=$GOOGLE_REMOTE_CACHE \
             --google_credentials=$GOOGLE_APPLICATION_CREDENTIALS \
+            --verbose_failures \
             :grpc
 
       - name: Test


### PR DESCRIPTION
Modified pipeline to use remote cache located in Google Cloud Storage with Google credentials.
Google credentials are stored in GitHub organization secrets.